### PR TITLE
feat: Implement incremental backups

### DIFF
--- a/zendesk_extractor/.gitignore
+++ b/zendesk_extractor/.gitignore
@@ -1,2 +1,3 @@
 .env
 __pycache__/
+../last_run.txt

--- a/zendesk_extractor/core/main.py
+++ b/zendesk_extractor/core/main.py
@@ -67,7 +67,7 @@ def fetch_tickets(session: Session, start_time: Optional[str] = None) -> Optiona
     params = {}
 
     if start_time:
-        params["query"] = f"type:ticket created>={start_time}"
+        params["query"] = f"type:ticket updated>={start_time}"
 
     while url:
         try:
@@ -192,7 +192,14 @@ def main() -> None:
     """
     try:
         session = get_zendesk_session()
-        start_date = (datetime.now() - timedelta(days=30)).strftime('%Y-%m-%d')
+
+        last_run_file = "last_run.txt"
+        try:
+            with open(last_run_file, "r") as f:
+                start_date = f.read().strip()
+        except FileNotFoundError:
+            start_date = (datetime.now() - timedelta(days=30)).strftime('%Y-%m-%d')
+
         tickets = fetch_tickets(session, start_time=start_date)
 
         if not tickets:
@@ -229,6 +236,9 @@ def main() -> None:
             except ZendeskExtractorError as e:
                 logging.error(f"An error occurred while processing ticket {ticket_id}: {e}")
                 continue
+
+        with open(last_run_file, "w") as f:
+            f.write(datetime.now().isoformat())
 
     except ZendeskExtractorError as e:
         logging.error(f"An unrecoverable error occurred: {e}")


### PR DESCRIPTION
This commit introduces the incremental backups feature to the Zendesk data extractor.

- A `last_run.txt` file is created in the root directory to store the timestamp of the last successful extraction.
- The `main` function in `zendesk_extractor/core/main.py` is modified to:
  - Read the timestamp from `last_run.txt`.
  - Use a default start date of 30 days ago if the file doesn't exist.
  - Pass the timestamp to the `fetch_tickets` function.
  - Write the current timestamp to `last_run.txt` at the end of a successful extraction.
- The `fetch_tickets` function is updated to use the `start_time` to query for tickets updated since that time.
- `last_run.txt` is added to the `.gitignore` file.